### PR TITLE
feat: set clickhouse resources to large

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -3055,7 +3055,7 @@ clickhouse:
   ## @param tls.resourcesPreset Set container resources according to one common preset (allowed values: none, nano, micro, small, medium, large, xlarge, 2xlarge). This is ignored if tls.resources is set (tls.resources is recommended for production).
   ## More information: https://github.com/bitnami/charts/blob/main/bitnami/common/templates/_resources.tpl#L15
   ##
-  resourcesPreset: "small"
+  resourcesPreset: "large"
 
   ## @param clickhouse.extraOverrides Extra configuration overrides (evaluated as a template) apart from the default
   ##


### PR DESCRIPTION
# Description

When sending k8s metrics clickhouse got overloaded and started to crash, to avoid this behavior, let's increase the resource to large; 